### PR TITLE
Fix Television channel parse errors when the user's shell is nushell

### DIFF
--- a/cable/termscope-alpha.toml
+++ b/cable/termscope-alpha.toml
@@ -3,6 +3,7 @@ name = "termscope-alpha"
 description = "Pick visible terminal targets in alphabetical order"
 
 [source]
+shell = "bash"
 command = [
   { name = "Alphabetical", run = "cat \"$TERMSCOPE_ALPHA_CANDIDATES\"" },
   { name = "Appearance", run = "cat \"$TERMSCOPE_APPEARANCE_CANDIDATES\"" },
@@ -16,6 +17,7 @@ frecency = false
 ctrl-s = "cycle_sources"
 
 [preview]
+shell = "bash"
 command = "\"$TERMSCOPE_PYTHON\" \"$TERMSCOPE_SCRIPT\" preview --pane-path \"$TERMSCOPE_PANE_PATH\" {split:\\t:0}"
 
 [ui]

--- a/cable/termscope-appearance.toml
+++ b/cable/termscope-appearance.toml
@@ -3,6 +3,7 @@ name = "termscope-appearance"
 description = "Pick visible terminal targets in appearance order"
 
 [source]
+shell = "bash"
 command = [
   { name = "Appearance", run = "cat \"$TERMSCOPE_APPEARANCE_CANDIDATES\"" },
   { name = "Alphabetical", run = "cat \"$TERMSCOPE_ALPHA_CANDIDATES\"" },
@@ -16,6 +17,7 @@ frecency = false
 ctrl-s = "cycle_sources"
 
 [preview]
+shell = "bash"
 command = "\"$TERMSCOPE_PYTHON\" \"$TERMSCOPE_SCRIPT\" preview --pane-path \"$TERMSCOPE_PANE_PATH\" {split:\\t:0}"
 
 [ui]


### PR DESCRIPTION
## Problem

Termscope's Television cable channels use **POSIX shell syntax**:

```toml
[source]
command = [
  { name = "Appearance", run = "cat \"$TERMSCOPE_APPEARANCE_CANDIDATES\"" },
  ...
]

[preview]
command = "\"$TERMSCOPE_PYTHON\" \"$TERMSCOPE_SCRIPT\" preview --pane-path \"$TERMSCOPE_PANE_PATH\" {split:\t:0}"
```

Television runs channel `source`/`preview`/`action` commands through the shell detected from `$SHELL` on Unix (unless a channel overrides it). For users whose login shell is **nushell**, the picker's source and preview both break with:

```
Error: nu::parser::parse_mismatch
x Parse mismatch during operation.
  -[source: 1:21]
1 | "$TERMSCOPE_PYTHON" "$TERMSCOPE_SCRIPT" preview --pane-path "$TERMSCOPE_PANE_PATH" ...
  AAAA
  - expected operator
```

nushell doesn't parse the POSIX-style `$VAR` expansion/quoting the way a POSIX shell does.

## Fix

Declare `shell = "bash"` on the `[source]` and `[preview]` sections of both built-in cable channels (`termscope-appearance.toml` and `termscope-alpha.toml`). These channels always emit POSIX syntax (they rely on `$TERMSCOPE_*` env expansion), so they should explicitly request a POSIX shell for the commands they run, matching how `npm.nix`-style channels already override the channel shell.

This is forward-compatible: bash exists on macOS and Linux (termscope's supported platforms), and the channels already depend on bash-isms in the form of `$VAR` env expansion.

## Testing

Reproduced the `nu::parser::parse_mismatch` error under nushell, then verified that after adding `shell = "bash"`:

- the channel TOML still parses and Television still accepts the channel;
- running the source/preview commands works under bash with the `$TERMSCOPE_*` env vars set;
- launching the picker on the cable directory no longer produces a nushell parse error.

Fixes termscoper failing for nushell users.