### PR TITLE
feat: Capture every pane in the current window/tab and merge visible links into the file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@
 
 Open the files and links your agent just mentioned.
 
-`termscope` turns terminal output into a jump list. It reads the active pane's
-visible terminal viewport, finds real files and URLs, then opens the selected
-target beside the conversation you were already reading.
+`termscope` turns terminal output into a jump list. It reads the visible
+terminal viewport of every pane in the current window/tab, finds real files and
+URLs, then opens the selected target beside the conversation you were already
+reading.
 
 ```text
 visible terminal viewport
@@ -35,11 +36,11 @@ Agents constantly mention files: stack traces, changed tests, docs, configs,
 links, PRs. `termscope` lets you keep up without doing the little dance:
 select text, copy, cd, paste, fix the path, add the line number.
 
-If it's visible in the pane and exists in the repo, you can jump to it.
+If it's visible in the window and exists in the repo, you can jump to it.
 
 Termscope stays conservative:
 
-- scans only the active pane's visible text
+- scans only the visible text of the current window's panes
 - verifies paths against the repo/worktree on disk
 - preserves `file:line` targets
 - falls back to a full repo picker when no visible file matches

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ File picker controls:
 | `Ctrl-Y` | Agent pane: send `/plannotator-annotate <file>`; shell pane: run `plannotator annotate <file>` |
 | `Ctrl-S` | Toggle appearance order / alphabetical sort |
 
+Visible URLs are listed after the files. On a URL row, `Enter`/`Ctrl-O` open it
+with the default opener and `Ctrl-Y` copies it.
+
 Link picker controls:
 
 | Key | Action |

--- a/cable/termscope-alpha.toml
+++ b/cable/termscope-alpha.toml
@@ -26,7 +26,7 @@ input_prompt = "> "
 
 [ui.preview_panel]
 size = 60
-footer = "Enter  Neovim  ·  Ctrl-O  Default app  ·  Ctrl-Y  Plannotator"
+footer = "Enter  Neovim  ·  Ctrl-O  Default app  ·  Ctrl-Y  Plannotator  ·  URLs: Enter opens, Ctrl-Y copies"
 border_type = "rounded"
 
 [ui.results_panel]

--- a/cable/termscope-appearance.toml
+++ b/cable/termscope-appearance.toml
@@ -26,7 +26,7 @@ input_prompt = "> "
 
 [ui.preview_panel]
 size = 60
-footer = "Enter  Neovim  ·  Ctrl-O  Default app  ·  Ctrl-Y  Plannotator"
+footer = "Enter  Neovim  ·  Ctrl-O  Default app  ·  Ctrl-Y  Plannotator  ·  URLs: Enter opens, Ctrl-Y copies"
 border_type = "rounded"
 
 [ui.results_panel]

--- a/termscope
+++ b/termscope
@@ -124,6 +124,33 @@ class TmuxBackend(MultiplexerBackend):
         return pane_path
 
     def capture_pane_text(self, pane_id: str) -> str:
+        text = self._capture_single(pane_id)
+        if not pane_id:
+            return text
+        try:
+            listing = subprocess.run(
+                ["tmux", "list-panes", "-t", pane_id, "-F", "#{pane_id}"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            canon = subprocess.run(
+                ["tmux", "display-message", "-p", "-t", pane_id, "#{pane_id}"],
+                text=True,
+                capture_output=True,
+                check=False,
+            ).stdout.strip()
+        except FileNotFoundError:
+            return text
+        if listing.returncode != 0:
+            return text
+        texts = [text]
+        for pid in listing.stdout.split():
+            if pid and pid != canon:
+                texts.append(self._capture_single(pid))
+        return "\n".join(texts)
+
+    def _capture_single(self, pane_id: str) -> str:
         cmd = ["tmux", "capture-pane", "-pJ"]
 
         # If the source pane is in copy mode, capture the scrolled viewport
@@ -263,13 +290,43 @@ class HerdrBackend(MultiplexerBackend):
         return pane_path
 
     def capture_pane_text(self, pane_id: str) -> str:
-        result = subprocess.run(
-            [self._herdr_bin(), "pane", "read", pane_id, "--source", "visible"],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        return result.stdout
+        texts = []
+        for pid in self._tab_pane_ids(pane_id):
+            result = subprocess.run(
+                [self._herdr_bin(), "pane", "read", pid, "--source", "visible"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            texts.append(result.stdout)
+        return "\n".join(texts)
+
+    def _tab_pane_ids(self, pane_id: str) -> list[str]:
+        """All panes in pane_id's tab — source pane first, skipping our own popup."""
+        # Sibling panes' relative paths resolve against the source pane's root.
+        try:
+            result = subprocess.run(
+                [self._herdr_bin(), "pane", "list"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            panes = json.loads(result.stdout)["result"]["panes"]
+        except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError):
+            return [pane_id]
+        tab_id = next((p.get("tab_id") for p in panes if p.get("pane_id") == pane_id), None)
+        if tab_id is None:
+            return [pane_id]
+        own_id = os.environ.get("HERDR_PANE_ID")
+        ids = [
+            p["pane_id"]
+            for p in panes
+            if p.get("tab_id") == tab_id and p["pane_id"] != own_id
+        ]
+        if pane_id not in ids:
+            return [pane_id]
+        ids.sort(key=lambda pid: pid != pane_id)
+        return ids
 
     def open_in_nvim_split(
         self, path: Path, line: str, pane_path: Path, pane_id: str
@@ -472,6 +529,15 @@ def extract_visible_links(screen_text: str, sort: str = "appearance") -> list[st
             add(m.group(0), i)
 
     return sort_items(matches, sort)
+
+
+def merge_link_candidates(candidates: list[str], screen_text: str) -> list[str]:
+    """Append visible URLs so one picker lists paths and links together."""
+    return candidates + [
+        link
+        for link in extract_visible_links(screen_text, sort="appearance")
+        if link not in candidates
+    ]
 
 
 # --------------------------------------------------------------------------- #
@@ -1125,6 +1191,9 @@ def preview_target(target_text: str, pane_path: Path) -> None:
 
 
 def _render_preview(target_text: str, pane_path: Path) -> None:
+    if target_text.startswith(("http://", "https://")):
+        print(target_text)
+        return
     parsed = parse_selected_target(target_text)
     search_root = find_search_root(pane_path)
     resolved = resolve_existing_path(parsed.path, pane_path, search_root)
@@ -1226,6 +1295,7 @@ def cmd_pick(args: argparse.Namespace) -> None:
     candidates = extract_visible_candidates(
         screen_text, repo_paths, search_root, source_pane_path, sort="appearance"
     )
+    candidates = merge_link_candidates(candidates, screen_text)
 
     state = DebugState(
         pane_path=str(pane_path),
@@ -1291,6 +1361,14 @@ def cmd_pick(args: argparse.Namespace) -> None:
         return
 
     key = picker_result.key or "enter"
+    if selection.startswith(("http://", "https://")):
+        state.mode = "url"
+        debug_dump(state)
+        if key == "ctrl-y":
+            copy_to_clipboard(selection)
+            return
+        open_url(selection)
+
     if key == "ctrl-o":
         mode = "default"
     elif key == "ctrl-y":

--- a/termscope
+++ b/termscope
@@ -996,11 +996,11 @@ def run_tv_full_repo(
     search_root: Path, sort: str = "appearance", prepend: list[str] | None = None
 ) -> PickerResult | None:
     """Show all repo files when no visible file exists; visible URLs stay listed first."""
-    files = list_repo_files(search_root)
-    if not files:
+    candidates = (prepend or []) + list_repo_files(search_root)
+    if not candidates:
         return None
     return _run_tv(
-        (prepend or []) + files,
+        candidates,
         f"All files — {display_path(search_root)}",
         ("ctrl-o", "ctrl-y"),
         sort=sort,

--- a/termscope
+++ b/termscope
@@ -321,10 +321,11 @@ class HerdrBackend(MultiplexerBackend):
             log_event("capture_tab_fallback", pane_id=pane_id, reason="source pane not listed")
             return [pane_id]
         own_id = os.environ.get("HERDR_PANE_ID")
+        popup_id = own_id if own_id != pane_id else None
         ids = [
             p.get("pane_id")
             for p in panes
-            if p.get("tab_id") == tab_id and p.get("pane_id") not in (None, own_id)
+            if p.get("tab_id") == tab_id and p.get("pane_id") not in (None, popup_id)
         ]
         if pane_id not in ids:
             return [pane_id]

--- a/termscope
+++ b/termscope
@@ -143,10 +143,11 @@ class TmuxBackend(MultiplexerBackend):
         except FileNotFoundError:
             return text
         if listing.returncode != 0:
+            log_event("capture_window_fallback", pane_id=pane_id, reason=listing.stderr.strip())
             return text
         texts = [text]
         for pid in listing.stdout.split():
-            if pid and pid != canon:
+            if pid and pid not in (canon, pane_id):
                 texts.append(self._capture_single(pid))
         return "\n".join(texts)
 
@@ -313,15 +314,17 @@ class HerdrBackend(MultiplexerBackend):
             )
             panes = json.loads(result.stdout)["result"]["panes"]
         except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError):
+            log_event("capture_tab_fallback", pane_id=pane_id, reason="pane list unreadable")
             return [pane_id]
         tab_id = next((p.get("tab_id") for p in panes if p.get("pane_id") == pane_id), None)
         if tab_id is None:
+            log_event("capture_tab_fallback", pane_id=pane_id, reason="source pane not listed")
             return [pane_id]
         own_id = os.environ.get("HERDR_PANE_ID")
         ids = [
-            p["pane_id"]
+            p.get("pane_id")
             for p in panes
-            if p.get("tab_id") == tab_id and p["pane_id"] != own_id
+            if p.get("tab_id") == tab_id and p.get("pane_id") not in (None, own_id)
         ]
         if pane_id not in ids:
             return [pane_id]
@@ -989,13 +992,15 @@ def sort_file_list(files: list[str], sort: str = "appearance") -> list[str]:
     return files
 
 
-def run_tv_full_repo(search_root: Path, sort: str = "appearance") -> PickerResult | None:
-    """Show all repo files when no visible candidate exists."""
+def run_tv_full_repo(
+    search_root: Path, sort: str = "appearance", prepend: list[str] | None = None
+) -> PickerResult | None:
+    """Show all repo files when no visible file exists; visible URLs stay listed first."""
     files = list_repo_files(search_root)
     if not files:
         return None
     return _run_tv(
-        files,
+        (prepend or []) + files,
         f"All files — {display_path(search_root)}",
         ("ctrl-o", "ctrl-y"),
         sort=sort,
@@ -1292,10 +1297,11 @@ def cmd_pick(args: argparse.Namespace) -> None:
     screen_text = strip_ansi(screen_text)
     repo_paths = list_repo_files(search_root)
     sort = getattr(args, "sort", None) or os.environ.get("TERMSCOPE_SORT", "appearance")
-    candidates = extract_visible_candidates(
+    file_candidates = extract_visible_candidates(
         screen_text, repo_paths, search_root, source_pane_path, sort="appearance"
     )
-    candidates = merge_link_candidates(candidates, screen_text)
+    candidates = merge_link_candidates(file_candidates, screen_text)
+    links = candidates[len(file_candidates):]
 
     state = DebugState(
         pane_path=str(pane_path),
@@ -1312,8 +1318,9 @@ def cmd_pick(args: argparse.Namespace) -> None:
     )
 
     # Filter out whitespace-only candidates that would produce an empty picker.
+    # Fallback keys off visible *files* only: a lone URL must not hide the repo.
     real_candidates = [c for c in candidates if c.strip()]
-    visible_empty = len(real_candidates) == 0
+    visible_empty = not any(c.strip() for c in file_candidates)
 
     if visible_empty:
         log_event(
@@ -1338,7 +1345,7 @@ def cmd_pick(args: argparse.Namespace) -> None:
     if visible_empty:
         # No visible files — fall back to full repo listing so the picker
         # is never empty.
-        picker_result = run_tv_full_repo(search_root, sort=sort)
+        picker_result = run_tv_full_repo(search_root, sort=sort, prepend=links)
         if picker_result is None:
             show_message("No files found in repo", backend)
             log_event("pick_empty_repo", pane_id=pane_id)
@@ -1363,11 +1370,15 @@ def cmd_pick(args: argparse.Namespace) -> None:
     key = picker_result.key or "enter"
     if selection.startswith(("http://", "https://")):
         state.mode = "url"
+        state.resolved_path = selection
         debug_dump(state)
+        log_event("pick_url", pane_id=pane_id, key=key, url=selection)
         if key == "ctrl-y":
             copy_to_clipboard(selection)
+            show_message("Link copied to clipboard", backend)
             return
         open_url(selection)
+        return
 
     if key == "ctrl-o":
         mode = "default"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -59,7 +59,7 @@ class TestManifest(unittest.TestCase):
             self.assertNotIn("'{}'", preview)
             self.assertEqual(
                 channel["ui"]["preview_panel"]["footer"],
-                "Enter  Neovim  ·  Ctrl-O  Default app  ·  Ctrl-Y  Plannotator",
+                "Enter  Neovim  ·  Ctrl-O  Default app  ·  Ctrl-Y  Plannotator  ·  URLs: Enter opens, Ctrl-Y copies",
             )
 
 

--- a/tests/test_termscope.py
+++ b/tests/test_termscope.py
@@ -335,12 +335,19 @@ class TestCandidateEncoding(unittest.TestCase):
 
 class TestCapturePaneVisibleOnly(unittest.TestCase):
     def test_no_limit_flag(self):
-        completed = SimpleNamespace(returncode=0, stdout="line1\nline2\n")
-        with patch.object(tfp.subprocess, "run", return_value=completed) as run:
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["tmux", "capture-pane"]:
+                return SimpleNamespace(returncode=0, stdout="line1\nline2\n")
+            return SimpleNamespace(returncode=0, stdout="")
+
+        with patch.object(tfp.subprocess, "run", side_effect=fake_run):
             result = tfp.capture_pane_text("%42")
 
         self.assertEqual(result, "line1\nline2\n")
-        cmd = run.call_args.args[0]
+        cmd = next(c for c in calls if c[:2] == ["tmux", "capture-pane"])
         self.assertNotIn("-S", cmd)
         # No numeric limit should be present
         for arg in cmd:
@@ -348,13 +355,85 @@ class TestCapturePaneVisibleOnly(unittest.TestCase):
                              f"unexpected limit arg: {arg}")
 
     def test_pane_id_passed(self):
-        completed = SimpleNamespace(returncode=0, stdout="pane text")
-        with patch.object(tfp.subprocess, "run", return_value=completed) as run:
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["tmux", "capture-pane"]:
+                return SimpleNamespace(returncode=0, stdout="pane text")
+            return SimpleNamespace(returncode=0, stdout="")
+
+        with patch.object(tfp.subprocess, "run", side_effect=fake_run):
             tfp.capture_pane_text("%99")
 
-        cmd = run.call_args.args[0]
+        cmd = next(c for c in calls if c[:2] == ["tmux", "capture-pane"])
         self.assertIn("-t", cmd)
         self.assertIn("%99", cmd)
+
+    def test_captures_all_window_panes(self):
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["tmux", "list-panes"]:
+                return SimpleNamespace(returncode=0, stdout="%1\n%2\n")
+            if cmd[:2] == ["tmux", "display-message"]:
+                if cmd[-1] == "#{pane_id}":
+                    return SimpleNamespace(returncode=0, stdout="%1\n")
+                return SimpleNamespace(returncode=0, stdout="0")
+            if cmd[:2] == ["tmux", "capture-pane"]:
+                target = cmd[cmd.index("-t") + 1]
+                return SimpleNamespace(returncode=0, stdout=f"text from {target}\n")
+            return SimpleNamespace(returncode=0, stdout="")
+
+        with patch.object(tfp.subprocess, "run", side_effect=fake_run):
+            result = tfp.capture_pane_text("%1")
+
+        self.assertEqual(result, "text from %1\n\ntext from %2\n")
+
+    def test_herdr_captures_all_tab_panes(self):
+        pane_list = {
+            "result": {
+                "panes": [
+                    {"pane_id": "w5:p1", "tab_id": "w5:t1"},
+                    {"pane_id": "w5:p2", "tab_id": "w5:t1"},
+                    {"pane_id": "w6:p1", "tab_id": "w6:t1"},
+                ]
+            }
+        }
+
+        def fake_run(cmd, **kwargs):
+            if cmd[1:3] == ["pane", "list"]:
+                return SimpleNamespace(returncode=0, stdout=json.dumps(pane_list))
+            if cmd[1:3] == ["pane", "read"]:
+                return SimpleNamespace(returncode=0, stdout=f"text from {cmd[3]}\n")
+            return SimpleNamespace(returncode=0, stdout="")
+
+        with patch.dict(tfp.os.environ, {"HERDR_PANE_ID": "w9:p9"}), \
+                patch.object(tfp.subprocess, "run", side_effect=fake_run):
+            result = tfp.HerdrBackend().capture_pane_text("w5:p1")
+
+        self.assertEqual(result, "text from w5:p1\n\ntext from w5:p2\n")
+
+
+class TestMergeLinkCandidates(unittest.TestCase):
+    def test_appends_urls_after_paths(self):
+        text = "see https://example.com/a and docs/x.md\n"
+        merged = tfp.merge_link_candidates(["docs/x.md"], text)
+        self.assertEqual(merged, ["docs/x.md", "https://example.com/a"])
+
+    def test_dedupes_existing(self):
+        text = "https://example.com/a\n"
+        merged = tfp.merge_link_candidates(["https://example.com/a"], text)
+        self.assertEqual(merged, ["https://example.com/a"])
+
+
+class TestUrlPreview(unittest.TestCase):
+    def test_preview_prints_url(self):
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            tfp._render_preview("https://example.com/a", Path("/tmp"))
+        self.assertEqual(buf.getvalue().strip(), "https://example.com/a")
 
     def test_copy_mode_viewport_capture(self):
         """When pane is in copy mode, capture the scrolled viewport."""

--- a/tests/test_termscope.py
+++ b/tests/test_termscope.py
@@ -388,6 +388,43 @@ class TestCapturePaneVisibleOnly(unittest.TestCase):
 
         self.assertEqual(result, "text from %1\n\ntext from %2\n")
 
+    def test_list_panes_failure_falls_back_to_source_pane(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["tmux", "list-panes"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="no server")
+            if cmd[:2] == ["tmux", "capture-pane"]:
+                return SimpleNamespace(returncode=0, stdout="text from %1\n")
+            return SimpleNamespace(returncode=0, stdout="")
+
+        with patch.object(tfp.subprocess, "run", side_effect=fake_run):
+            result = tfp.capture_pane_text("%1")
+
+        self.assertEqual(result, "text from %1\n")
+        captures = [c for c in calls if c[:2] == ["tmux", "capture-pane"]]
+        self.assertEqual(len(captures), 1)
+
+    def test_alias_pane_id_not_double_captured(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["tmux", "list-panes"]:
+                return SimpleNamespace(returncode=0, stdout="%1\n%2\n")
+            if cmd[:2] == ["tmux", "display-message"] and cmd[-1] == "#{pane_id}":
+                return SimpleNamespace(returncode=0, stdout="%1\n")
+            if cmd[:2] == ["tmux", "capture-pane"]:
+                return SimpleNamespace(returncode=0, stdout="x\n")
+            return SimpleNamespace(returncode=0, stdout="0")
+
+        with patch.object(tfp.subprocess, "run", side_effect=fake_run):
+            tfp.capture_pane_text("main:1.0")
+
+        captures = [c[c.index("-t") + 1] for c in calls if c[:2] == ["tmux", "capture-pane"]]
+        self.assertEqual(captures, ["main:1.0", "%2"])
+
     def test_herdr_captures_all_tab_panes(self):
         pane_list = {
             "result": {
@@ -411,6 +448,24 @@ class TestCapturePaneVisibleOnly(unittest.TestCase):
             result = tfp.HerdrBackend().capture_pane_text("w5:p1")
 
         self.assertEqual(result, "text from w5:p1\n\ntext from w5:p2\n")
+
+    def test_herdr_skips_own_pane_and_bad_entries(self):
+        pane_list = {
+            "result": {
+                "panes": [
+                    {"pane_id": "w5:p2", "tab_id": "w5:t1"},
+                    {"tab_id": "w5:t1"},
+                    {"pane_id": "w5:p1", "tab_id": "w5:t1"},
+                    {"pane_id": "w5:p3", "tab_id": "w5:t1"},
+                ]
+            }
+        }
+        completed = SimpleNamespace(returncode=0, stdout=json.dumps(pane_list))
+        with patch.dict(tfp.os.environ, {"HERDR_PANE_ID": "w5:p3"}), \
+                patch.object(tfp.subprocess, "run", return_value=completed):
+            ids = tfp.HerdrBackend()._tab_pane_ids("w5:p1")
+
+        self.assertEqual(ids, ["w5:p1", "w5:p2"])
 
 
 class TestMergeLinkCandidates(unittest.TestCase):
@@ -616,6 +671,51 @@ class TestCancelledPickerNoOpen(unittest.TestCase):
             tfp.cmd_pick(args)
 
         mock_open.assert_not_called()
+
+
+class TestPickUrlSelection(unittest.TestCase):
+    def _run(self, key):
+        args = SimpleNamespace(pane_path="/tmp/repo", pane_id="%1")
+        result = tfp.PickerResult(selection="https://x.test/a", key=key)
+        with patch.object(tfp, "capture_pane_text", return_value="https://x.test/a\n"), \
+             patch.object(tfp, "strip_ansi", side_effect=lambda x: x), \
+             patch.object(tfp, "list_repo_files", return_value=["src/main.py"]), \
+             patch.object(tfp, "extract_visible_candidates", return_value=["src/main.py"]), \
+             patch.object(tfp, "run_tv_visible", return_value=result) as tv, \
+             patch.object(tfp, "open_url") as opener, \
+             patch.object(tfp, "copy_to_clipboard") as clip, \
+             patch.object(tfp, "show_message"), \
+             patch.object(tfp, "_open_target") as open_target, \
+             patch.object(tfp.subprocess, "run"):
+            tfp.cmd_pick(args)
+        return tv, opener, clip, open_target
+
+    def test_enter_opens_url(self):
+        tv, opener, clip, open_target = self._run(None)
+        self.assertEqual(tv.call_args.args[0], ["src/main.py", "https://x.test/a"])
+        opener.assert_called_once_with("https://x.test/a")
+        open_target.assert_not_called()
+
+    def test_ctrl_y_copies_url(self):
+        _, opener, clip, open_target = self._run("ctrl-y")
+        clip.assert_called_once_with("https://x.test/a")
+        opener.assert_not_called()
+        open_target.assert_not_called()
+
+    def test_url_only_screen_still_falls_back_to_full_repo(self):
+        args = SimpleNamespace(pane_path="/tmp/repo", pane_id="%1")
+        with patch.object(tfp, "capture_pane_text", return_value="https://x.test/a\n"), \
+             patch.object(tfp, "strip_ansi", side_effect=lambda x: x), \
+             patch.object(tfp, "list_repo_files", return_value=["src/main.py"]), \
+             patch.object(tfp, "extract_visible_candidates", return_value=[]), \
+             patch.object(tfp, "run_tv_visible") as visible, \
+             patch.object(tfp, "run_tv_full_repo", return_value=None) as full, \
+             patch.object(tfp, "show_message"), \
+             patch.object(tfp.subprocess, "run"):
+            tfp.cmd_pick(args)
+        visible.assert_not_called()
+        full.assert_called_once()
+        self.assertEqual(full.call_args.kwargs["prepend"], ["https://x.test/a"])
 
 
 class TestExtractVisibleCandidatesLineSuffix(unittest.TestCase):

--- a/tests/test_termscope.py
+++ b/tests/test_termscope.py
@@ -1031,6 +1031,23 @@ class TestTelevisionCommands(unittest.TestCase):
         self.assertEqual(run.call_args.args[0], ["src/main.py"])
         self.assertEqual(run.call_args.kwargs["sort"], "alpha")
 
+    def test_full_repo_keeps_prepended_links_when_repo_is_empty(self):
+        url = "https://example.com"
+        with patch.object(tfp, "list_repo_files", return_value=[]), \
+             patch.object(tfp, "_run_tv", return_value=tfp.PickerResult(selection=url)) as run:
+            result = tfp.run_tv_full_repo(Path("/tmp/repo"), prepend=[url])
+
+        self.assertEqual(result.selection, url)
+        self.assertEqual(run.call_args.args[0], [url])
+
+    def test_full_repo_returns_none_when_all_candidates_are_empty(self):
+        with patch.object(tfp, "list_repo_files", return_value=[]), \
+             patch.object(tfp, "_run_tv") as run:
+            result = tfp.run_tv_full_repo(Path("/tmp/repo"))
+
+        self.assertIsNone(result)
+        run.assert_not_called()
+
     def test_missing_television_exits_nonzero(self):
         import io
         with patch.object(tfp.shutil, "which", return_value=None), \

--- a/tests/test_termscope.py
+++ b/tests/test_termscope.py
@@ -449,7 +449,23 @@ class TestCapturePaneVisibleOnly(unittest.TestCase):
 
         self.assertEqual(result, "text from w5:p1\n\ntext from w5:p2\n")
 
-    def test_herdr_skips_own_pane_and_bad_entries(self):
+    def test_herdr_direct_invocation_keeps_source_and_siblings(self):
+        pane_list = {
+            "result": {
+                "panes": [
+                    {"pane_id": "w5:p2", "tab_id": "w5:t1"},
+                    {"pane_id": "w5:p1", "tab_id": "w5:t1"},
+                ]
+            }
+        }
+        completed = SimpleNamespace(returncode=0, stdout=json.dumps(pane_list))
+        with patch.dict(tfp.os.environ, {"HERDR_PANE_ID": "w5:p1"}), \
+                patch.object(tfp.subprocess, "run", return_value=completed):
+            ids = tfp.HerdrBackend()._tab_pane_ids("w5:p1")
+
+        self.assertEqual(ids, ["w5:p1", "w5:p2"])
+
+    def test_herdr_skips_distinct_popup_and_bad_entries(self):
         pane_list = {
             "result": {
                 "panes": [


### PR DESCRIPTION
## Motivation

When running two agent sessions side by side (e.g. Claude Code in both halves of a tmux window or herdr tab), the picker only reads the focused pane's viewport. A path mentioned in the neighbouring pane is invisible to it — you have to focus that pane first and reopen the picker. The file picker and link picker are also separate flows, so "open the thing my agent just mentioned" needs two keybindings depending on whether it's a path or a URL.

## Changes

**Whole-window capture** — `capture_pane_text` now reads the visible viewport of every pane in the source window (tmux) / tab (herdr), source pane first:

- tmux: panes enumerated via `list-panes`, the source pane id canonicalised via `display-message '#{pane_id}'` so alternate id forms don't double-capture; the existing copy-mode viewport logic is preserved per pane (`_capture_single`)
- herdr: panes enumerated via `pane list` filtered by the source pane's `tab_id`; the plugin's own popup pane is excluded via `HERDR_PANE_ID`
- candidate order still follows on-screen appearance, source pane's hits first; relative paths resolve against the source pane's root
- any enumeration failure falls back to the previous single-pane behaviour

**Links merged into the file picker** — `pick` appends visible URLs (deduped) after file candidates via a new `merge_link_candidates` helper, so one picker lists paths and links together. Selecting a URL: Enter opens it with the default opener, Ctrl-Y copies it, and the preview shows the URL. The dedicated `links` flow is unchanged.

## Testing

- `python -m unittest discover tests` — 122 tests green
- New coverage: whole-window capture for both backends, source-pane-first ordering, link merge/dedupe, URL preview
- Two existing capture tests updated from single `return_value` mocks to command-keyed fakes, since capture now issues one subprocess call per pane
- Verified live in herdr: a tab with two Claude Code panes now yields the union of both panes' paths plus visible URLs