### PR TITLE
fix(pick): match repo paths only at path boundaries

### DIFF
--- a/termscope
+++ b/termscope
@@ -593,6 +593,25 @@ def list_repo_files(search_root: Path) -> list[str]:
 # Candidate extraction
 # --------------------------------------------------------------------------- #
 
+PATH_EDGE = r"[A-Za-z0-9_./\\-]"
+
+
+def find_path_token(haystack: str, needle: str, extensionless: bool = False) -> int:
+    """Position of needle standing on its own, else -1.
+
+    A path character on the left rules it out: the "README.md" in
+    "docs/guide/README.md" is that file. Extensionless needles need a right
+    edge too, so "README" cannot claim "README.md"; the rest keep a loose one,
+    so "src" still matches in "src/main.py". ":" stays out, for line suffixes.
+    """
+    if not needle:
+        return -1
+    right = rf"(?!{PATH_EDGE})" if extensionless else ""
+    pattern = rf"(?<!{PATH_EDGE}){re.escape(needle)}{right}"
+    m = re.search(pattern, haystack)
+    return m.start() if m else -1
+
+
 def extract_visible_candidates(
     screen_text: str,
     repo_paths: list[str],
@@ -690,15 +709,17 @@ def extract_visible_candidates(
     for path in repo_paths:
         base = os.path.basename(path)
         abs_path = os.path.join(str(search_root), path)
-        variants = [path, "./" + path, abs_path, home_display(abs_path)]
+        variants = [
+            (v, False) for v in (path, "./" + path, abs_path, home_display(abs_path))
+        ]
 
         if path.endswith(".md"):
-            variants.append(path[:-3])
+            variants.append((path[:-3], True))
             if base.endswith(".md"):
-                variants.append(base[:-3])
+                variants.append((base[:-3], True))
 
-        for variant in variants:
-            pos = joined.find(variant)
+        for variant, extensionless in variants:
+            pos = find_path_token(joined, variant, extensionless)
             if pos >= 0:
                 after = joined[pos + len(variant):]
                 line_m = re.match(r':(\d+)(?::\d+)?', after)

--- a/tests/test_termscope.py
+++ b/tests/test_termscope.py
@@ -248,6 +248,17 @@ class TestExtractVisibleCandidates(unittest.TestCase):
         cands = tfp.extract_visible_candidates(text, repo, self.tmp, self.tmp)
         self.assertIn("README.md", cands)
 
+    def test_md_extension_omission_needs_a_whole_word(self):
+        # "README" inside a longer path is not a mention of the root README.md.
+        nested = self.tmp / "docs" / "guide"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "README.md").write_text("# nested")
+        text = "put the findings into docs/guide/README.md as the committed version"
+        repo = ["README.md", "docs/guide/README.md", "src/main.py"]
+        cands = tfp.extract_visible_candidates(text, repo, self.tmp, self.tmp)
+        self.assertIn("docs/guide/README.md", cands)
+        self.assertNotIn("README.md", cands)
+
     def test_basename_exact_line_match(self):
         text = "README.md\nsrc/main.py"
         repo = ["README.md", "src/main.py"]


### PR DESCRIPTION
This PR fixes the picker that returned 42 rows in my herdr pane when there was just one file path. Many of these files don't exist on my screen. Every `README.md` in the repo turned up in this picker.

Repo paths are matched with `joined.find(variant)`, and the variants include the basename minus `.md`. So a line mentioning `research/breakout_qa_bot/README.md` contains both `README.md` and `README` as substrings, and every markdown file with that basename matches. If there are 40 READMEs in the repo, all 40 rows will appear in the picker.

Still a substring search, but it now asks for a path boundary. A path character on the left rules a match out, and extensionless variants need a right edge as well, so bare `README` cannot claim `README.md`. `src` still shows up when only `src/main.py` is visible, and `main.py:12` keeps its line number.

One test added, the other 133 pass. Note that a line holding just `README.md` still matches every namesake, through the `base_variants` block. That needs a policy so I left it to your call.